### PR TITLE
Release/v0.1.10

### DIFF
--- a/asserts/json/json.go
+++ b/asserts/json/json.go
@@ -40,33 +40,33 @@ func Length(expression string, expectLength int) cute.AssertBody {
 	}
 }
 
-// GreaterThan is a function to asserts that value is greater than the given length
+// LengthGreaterThan is a function to asserts that value is greater than the given length
 // About expression - https://goessner.net/articles/JsonPath/
-func GreaterThan(expression string, minimumLength int) cute.AssertBody {
+func LengthGreaterThan(expression string, minimumLength int) cute.AssertBody {
 	return func(body []byte) error {
 		return greaterThan(body, expression, minimumLength)
 	}
 }
 
-// GreaterOrEqualThan is a function to asserts that value is greater or equal than the given length
+// LengthGreaterOrEqualThan is a function to asserts that value is greater or equal than the given length
 // About expression - https://goessner.net/articles/JsonPath/
-func GreaterOrEqualThan(expression string, minimumLength int) cute.AssertBody {
+func LengthGreaterOrEqualThan(expression string, minimumLength int) cute.AssertBody {
 	return func(body []byte) error {
 		return greaterOrEqualThan(body, expression, minimumLength)
 	}
 }
 
-// LessThan is a function to asserts that value is less than the given length
+// LengthLessThan is a function to asserts that value is less than the given length
 // About expression - https://goessner.net/articles/JsonPath/
-func LessThan(expression string, maximumLength int) cute.AssertBody {
+func LengthLessThan(expression string, maximumLength int) cute.AssertBody {
 	return func(body []byte) error {
 		return lessThan(body, expression, maximumLength)
 	}
 }
 
-// LessOrEqualThan is a function to asserts that value is less or equal than the given length
+// LengthLessOrEqualThan is a function to asserts that value is less or equal than the given length
 // About expression - https://goessner.net/articles/JsonPath/
-func LessOrEqualThan(expression string, maximumLength int) cute.AssertBody {
+func LengthLessOrEqualThan(expression string, maximumLength int) cute.AssertBody {
 	return func(body []byte) error {
 		return lessOrEqualThan(body, expression, maximumLength)
 	}

--- a/asserts/json/json_test.go
+++ b/asserts/json/json_test.go
@@ -556,6 +556,12 @@ func TestEqual(t *testing.T) {
 			expression: "$.a",
 			expect:     []byte("not_correct"),
 		},
+		{
+			caseName:   "check 186135434",
+			data:       `{"a":186135434, "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     186135434,
+		},
 	}
 
 	for _, test := range tests {

--- a/asserts/json/json_test.go
+++ b/asserts/json/json_test.go
@@ -273,7 +273,7 @@ func TestGreaterThan(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := GreaterThan(test.expression, test.expect.(int))([]byte(test.data))
+		err := LengthGreaterThan(test.expression, test.expect.(int))([]byte(test.data))
 
 		if test.IsNilErr {
 			require.NoError(t, err, "failed test %v", test.caseName)
@@ -354,7 +354,7 @@ func TestGreaterOrEqualThan(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := GreaterOrEqualThan(test.expression, test.expect.(int))([]byte(test.data))
+		err := LengthGreaterOrEqualThan(test.expression, test.expect.(int))([]byte(test.data))
 
 		if test.IsNilErr {
 			require.NoError(t, err, "failed test %v", test.caseName)
@@ -414,7 +414,7 @@ func TestLessThan(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := LessThan(test.expression, test.expect.(int))([]byte(test.data))
+		err := LengthLessThan(test.expression, test.expect.(int))([]byte(test.data))
 
 		if test.IsNilErr {
 			require.NoError(t, err, "failed test %v", test.caseName)
@@ -495,7 +495,7 @@ func TestLessOrEqualThan(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := LessOrEqualThan(test.expression, test.expect.(int))([]byte(test.data))
+		err := LengthLessOrEqualThan(test.expression, test.expect.(int))([]byte(test.data))
 
 		if test.IsNilErr {
 			require.NoError(t, err, "failed test %v", test.caseName)

--- a/asserts/json/json_test.go
+++ b/asserts/json/json_test.go
@@ -223,7 +223,7 @@ func TestLength(t *testing.T) {
 	}
 }
 
-func TestGreaterThan(t *testing.T) {
+func TestLengthGreaterThan(t *testing.T) {
 	tests := []jsonTest{
 		{
 			caseName:   "correct check array",
@@ -283,7 +283,7 @@ func TestGreaterThan(t *testing.T) {
 	}
 }
 
-func TestGreaterOrEqualThan(t *testing.T) {
+func TestLengthGreaterOrEqualThan(t *testing.T) {
 	tests := []jsonTest{
 		{
 			caseName:   "correct check array",
@@ -364,7 +364,7 @@ func TestGreaterOrEqualThan(t *testing.T) {
 	}
 }
 
-func TestLessThan(t *testing.T) {
+func TestLengthLessThan(t *testing.T) {
 	tests := []jsonTest{
 		{
 			caseName:   "correct check array",
@@ -424,7 +424,7 @@ func TestLessThan(t *testing.T) {
 	}
 }
 
-func TestLessOrEqualThan(t *testing.T) {
+func TestLengthLessOrEqualThan(t *testing.T) {
 	tests := []jsonTest{
 		{
 			caseName:   "correct check array",
@@ -561,6 +561,20 @@ func TestEqual(t *testing.T) {
 			data:       `{"a":186135434, "b":{"bs":"sb"}}`,
 			expression: "$.a",
 			expect:     186135434,
+		},
+		{
+			caseName:   "check float",
+			data:       `{"a":1.0000001, "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     1.0000001,
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "check float 2",
+			data:       `{"a":999.0000001, "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     999.0000001,
+			IsNilErr:   true,
 		},
 	}
 

--- a/asserts/json/util.go
+++ b/asserts/json/util.go
@@ -174,6 +174,10 @@ func notPresent(data []byte, expression string) error {
 }
 
 func objectsAreEqual(expect, actual interface{}) bool {
+	if reflect.DeepEqual(expect, actual) {
+		return true
+	}
+
 	if expect == nil || actual == nil {
 		return expect == actual
 	}

--- a/builder.go
+++ b/builder.go
@@ -9,6 +9,11 @@ import (
 
 const defaultHTTPTimeout = 30
 
+var (
+	errorFunctionIsNil = "Function must be not nil"
+	errorAssertIsNil   = "Assert must be not nil"
+)
+
 // HTTPTestMaker is a creator tests
 type HTTPTestMaker struct {
 	httpClient *http.Client
@@ -377,6 +382,12 @@ func (it *cute) ExpectJSONSchemaFile(filePath string) ExpectHTTPBuilder {
 }
 
 func (it *cute) AssertBody(asserts ...AssertBody) ExpectHTTPBuilder {
+	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+	}
+
 	it.tests[it.countTests].Expect.AssertBody = append(it.tests[it.countTests].Expect.AssertBody, asserts...)
 
 	return it
@@ -384,6 +395,10 @@ func (it *cute) AssertBody(asserts ...AssertBody) ExpectHTTPBuilder {
 
 func (it *cute) OptionalAssertBody(asserts ...AssertBody) ExpectHTTPBuilder {
 	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+
 		it.tests[it.countTests].Expect.AssertBody = append(it.tests[it.countTests].Expect.AssertBody, optionalAssertBody(assert))
 	}
 
@@ -391,6 +406,12 @@ func (it *cute) OptionalAssertBody(asserts ...AssertBody) ExpectHTTPBuilder {
 }
 
 func (it *cute) AssertHeaders(asserts ...AssertHeaders) ExpectHTTPBuilder {
+	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+	}
+
 	it.tests[it.countTests].Expect.AssertHeaders = append(it.tests[it.countTests].Expect.AssertHeaders, asserts...)
 
 	return it
@@ -398,6 +419,10 @@ func (it *cute) AssertHeaders(asserts ...AssertHeaders) ExpectHTTPBuilder {
 
 func (it *cute) OptionalAssertHeaders(asserts ...AssertHeaders) ExpectHTTPBuilder {
 	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+
 		it.tests[it.countTests].Expect.AssertHeaders = append(it.tests[it.countTests].Expect.AssertHeaders, optionalAssertHeaders(assert))
 	}
 
@@ -405,6 +430,12 @@ func (it *cute) OptionalAssertHeaders(asserts ...AssertHeaders) ExpectHTTPBuilde
 }
 
 func (it *cute) AssertResponse(asserts ...AssertResponse) ExpectHTTPBuilder {
+	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+	}
+
 	it.tests[it.countTests].Expect.AssertResponse = append(it.tests[it.countTests].Expect.AssertResponse, asserts...)
 
 	return it
@@ -412,6 +443,10 @@ func (it *cute) AssertResponse(asserts ...AssertResponse) ExpectHTTPBuilder {
 
 func (it *cute) OptionalAssertResponse(asserts ...AssertResponse) ExpectHTTPBuilder {
 	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+
 		it.tests[it.countTests].Expect.AssertResponse = append(it.tests[it.countTests].Expect.AssertResponse, optionalAssertResponse(assert))
 	}
 
@@ -419,6 +454,12 @@ func (it *cute) OptionalAssertResponse(asserts ...AssertResponse) ExpectHTTPBuil
 }
 
 func (it *cute) AssertBodyT(asserts ...AssertBodyT) ExpectHTTPBuilder {
+	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+	}
+
 	it.tests[it.countTests].Expect.AssertBodyT = append(it.tests[it.countTests].Expect.AssertBodyT, asserts...)
 
 	return it
@@ -426,6 +467,10 @@ func (it *cute) AssertBodyT(asserts ...AssertBodyT) ExpectHTTPBuilder {
 
 func (it *cute) OptionalAssertBodyT(asserts ...AssertBodyT) ExpectHTTPBuilder {
 	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+
 		it.tests[it.countTests].Expect.AssertBodyT = append(it.tests[it.countTests].Expect.AssertBodyT, optionalAssertBodyT(assert))
 	}
 
@@ -433,6 +478,12 @@ func (it *cute) OptionalAssertBodyT(asserts ...AssertBodyT) ExpectHTTPBuilder {
 }
 
 func (it *cute) AssertHeadersT(asserts ...AssertHeadersT) ExpectHTTPBuilder {
+	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+	}
+
 	it.tests[it.countTests].Expect.AssertHeadersT = append(it.tests[it.countTests].Expect.AssertHeadersT, asserts...)
 
 	return it
@@ -440,6 +491,10 @@ func (it *cute) AssertHeadersT(asserts ...AssertHeadersT) ExpectHTTPBuilder {
 
 func (it *cute) OptionalAssertHeadersT(asserts ...AssertHeadersT) ExpectHTTPBuilder {
 	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+
 		it.tests[it.countTests].Expect.AssertHeadersT = append(it.tests[it.countTests].Expect.AssertHeadersT, optionalAssertHeadersT(assert))
 	}
 
@@ -447,6 +502,12 @@ func (it *cute) OptionalAssertHeadersT(asserts ...AssertHeadersT) ExpectHTTPBuil
 }
 
 func (it *cute) AssertResponseT(asserts ...AssertResponseT) ExpectHTTPBuilder {
+	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+	}
+
 	it.tests[it.countTests].Expect.AssertResponseT = append(it.tests[it.countTests].Expect.AssertResponseT, asserts...)
 
 	return it
@@ -454,6 +515,10 @@ func (it *cute) AssertResponseT(asserts ...AssertResponseT) ExpectHTTPBuilder {
 
 func (it *cute) OptionalAssertResponseT(asserts ...AssertResponseT) ExpectHTTPBuilder {
 	for _, assert := range asserts {
+		if assert == nil {
+			panic(errorAssertIsNil)
+		}
+
 		it.tests[it.countTests].Expect.AssertResponseT = append(it.tests[it.countTests].Expect.AssertResponseT, optionalAssertResponseT(assert))
 	}
 

--- a/builder.go
+++ b/builder.go
@@ -154,16 +154,16 @@ func createDefaultTests(m *HTTPTestMaker) []*Test {
 }
 
 func createDefaultTest(m *HTTPTestMaker) *Test {
-	after := make([]AfterExecute, 0, 0)
+	after := make([]AfterExecute, 0)
 	copy(after, m.middleware.After)
 
-	afterT := make([]AfterExecuteT, 0, 0)
+	afterT := make([]AfterExecuteT, 0)
 	copy(afterT, m.middleware.AfterT)
 
-	before := make([]BeforeExecute, 0, 0)
+	before := make([]BeforeExecute, 0)
 	copy(before, m.middleware.Before)
 
-	beforeT := make([]BeforeExecuteT, 0, 0)
+	beforeT := make([]BeforeExecuteT, 0)
 	copy(beforeT, m.middleware.BeforeT)
 
 	middleware := &Middleware{

--- a/builder.go
+++ b/builder.go
@@ -156,24 +156,16 @@ func createDefaultTests(m *HTTPTestMaker) []*Test {
 
 func createDefaultTest(m *HTTPTestMaker) *Test {
 	after := make([]AfterExecute, 0, len(m.middleware.After))
-	for _, execute := range m.middleware.After {
-		after = append(after, execute)
-	}
+	after = append(after, m.middleware.After...)
 
 	afterT := make([]AfterExecuteT, 0, len(m.middleware.AfterT))
-	for _, executeT := range m.middleware.AfterT {
-		afterT = append(afterT, executeT)
-	}
+	afterT = append(afterT, m.middleware.AfterT...)
 
 	before := make([]BeforeExecute, 0, len(m.middleware.Before))
-	for _, execute := range m.middleware.Before {
-		before = append(before, execute)
-	}
+	before = append(before, m.middleware.Before...)
 
 	beforeT := make([]BeforeExecuteT, 0, len(m.middleware.BeforeT))
-	for _, executeT := range m.middleware.BeforeT {
-		beforeT = append(beforeT, executeT)
-	}
+	beforeT = append(beforeT, m.middleware.BeforeT...)
 
 	middleware := &Middleware{
 		After:   after,

--- a/builder.go
+++ b/builder.go
@@ -124,8 +124,9 @@ func NewHTTPTestMaker(opts ...Option) *HTTPTestMaker {
 	}
 
 	m := &HTTPTestMaker{
-		httpClient: httpClient,
-		middleware: o.middleware,
+		hardValidation: o.hardValidation,
+		httpClient:     httpClient,
+		middleware:     o.middleware,
 	}
 
 	return m
@@ -154,17 +155,25 @@ func createDefaultTests(m *HTTPTestMaker) []*Test {
 }
 
 func createDefaultTest(m *HTTPTestMaker) *Test {
-	after := make([]AfterExecute, 0)
-	copy(after, m.middleware.After)
+	after := make([]AfterExecute, 0, len(m.middleware.After))
+	for _, execute := range m.middleware.After {
+		after = append(after, execute)
+	}
 
-	afterT := make([]AfterExecuteT, 0)
-	copy(afterT, m.middleware.AfterT)
+	afterT := make([]AfterExecuteT, 0, len(m.middleware.AfterT))
+	for _, executeT := range m.middleware.AfterT {
+		afterT = append(afterT, executeT)
+	}
 
-	before := make([]BeforeExecute, 0)
-	copy(before, m.middleware.Before)
+	before := make([]BeforeExecute, 0, len(m.middleware.Before))
+	for _, execute := range m.middleware.Before {
+		before = append(before, execute)
+	}
 
-	beforeT := make([]BeforeExecuteT, 0)
-	copy(beforeT, m.middleware.BeforeT)
+	beforeT := make([]BeforeExecuteT, 0, len(m.middleware.BeforeT))
+	for _, executeT := range m.middleware.BeforeT {
+		beforeT = append(beforeT, executeT)
+	}
 
 	middleware := &Middleware{
 		After:   after,

--- a/builder_test.go
+++ b/builder_test.go
@@ -116,7 +116,7 @@ func TestNewTestBuilder(t *testing.T) {
 	require.NotNil(t, ht.tests[0].Middleware)
 	require.NotNil(t, ht.tests[0].AllureStep)
 	require.NotNil(t, ht.allureInfo)
-	require.NotNil(t, ht.httpClient)
+	require.NotNil(t, ht.baseProps.httpClient)
 }
 
 func TestHTTPTestMaker(t *testing.T) {
@@ -312,14 +312,18 @@ func TestHTTPTestMaker(t *testing.T) {
 }
 
 func TestCreateDefaultTest(t *testing.T) {
-	defaultClient := http.DefaultClient
+	resTest := createDefaultTest(&HTTPTestMaker{httpClient: http.DefaultClient, middleware: new(Middleware)})
 
-	resTest := createDefaultTest(defaultClient)
 	require.Equal(t, &Test{
 		httpClient: http.DefaultClient,
 		Name:       "",
 		AllureStep: new(AllureStep),
-		Middleware: new(Middleware),
+		Middleware: &Middleware{
+			After:   make([]AfterExecute, 0, 0),
+			AfterT:  make([]AfterExecuteT, 0, 0),
+			Before:  make([]BeforeExecute, 0, 0),
+			BeforeT: make([]BeforeExecuteT, 0, 0),
+		},
 		Request: &Request{
 			Repeat: new(RequestRepeatPolitic),
 		},
@@ -338,10 +342,12 @@ func TestCreateTableTest(t *testing.T) {
 
 func TestPutNewTest(t *testing.T) {
 	tests := make([]*Test, 1)
-	tests[0] = createDefaultTest(http.DefaultClient)
+	tests[0] = createDefaultTest(&HTTPTestMaker{httpClient: http.DefaultClient, middleware: new(Middleware)})
 
 	var (
-		c            = &cute{tests: tests}
+		c = &cute{tests: tests, baseProps: &HTTPTestMaker{
+			middleware: &Middleware{},
+		}}
 		reqOne, _    = http.NewRequest("GET", "URL_1", nil)
 		expectOne    = &Expect{Code: 200}
 		reqSecond, _ = http.NewRequest("POST", "URL_1", nil)
@@ -362,7 +368,7 @@ func TestPutNewTest(t *testing.T) {
 
 func TestPutTests(t *testing.T) {
 	var (
-		tests        = createDefaultTests(http.DefaultClient)
+		tests        = createDefaultTests(&HTTPTestMaker{httpClient: http.DefaultClient, middleware: new(Middleware)})
 		c            = &cute{tests: tests}
 		reqOne, _    = http.NewRequest("GET", "URL_1", nil)
 		expectOne    = &Expect{Code: 200}

--- a/cute.go
+++ b/cute.go
@@ -2,7 +2,6 @@ package cute
 
 import (
 	"context"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -13,7 +12,7 @@ import (
 )
 
 type cute struct {
-	httpClient *http.Client
+	baseProps *HTTPTestMaker
 
 	parallel bool
 

--- a/examples/single_test.go
+++ b/examples/single_test.go
@@ -21,21 +21,6 @@ import (
 	"github.com/ozontech/cute/asserts/json"
 )
 
-func TestUploadfile(t *testing.T) {
-	cute.NewTestBuilder().
-		Title("Super test").
-		Create().
-		RequestBuilder(
-			cute.WithURI("http://localhost:7000/v1/admin/banner"),
-			cute.WithMethod("POST"),
-			cute.WithFormKV("body", []byte("{  \"banner\": {    \"companies\": [],    \"finish_date\": \"2023-10-02\",    \"start_date\": \"2021-01-08\",    \"priority\": 0,    \"url\": \"\",    \"users\": []  }}")),
-			cute.WithFileFormKV("image", &cute.File{
-				Path: "/Users/makarovserge/Downloads/gogogo.png",
-			}),
-		).
-		ExecuteTest(context.Background(), t)
-}
-
 func Test_Single_1(t *testing.T) {
 	cute.NewTestBuilder().
 		Title("Single test with default T").
@@ -102,7 +87,7 @@ func Test_Single_2_AllureRunner(t *testing.T) {
 			Description("some_description").
 			Create().
 			RequestRepeatDelay(3*time.Second). // delay before new try
-			RequestRepeat(3).                  // count attempts
+			RequestRepeat(3). // count attempts
 			RequestBuilder(
 				cute.WithURL(u),
 				cute.WithMethod(http.MethodGet),

--- a/examples/single_test.go
+++ b/examples/single_test.go
@@ -87,7 +87,7 @@ func Test_Single_2_AllureRunner(t *testing.T) {
 			Description("some_description").
 			Create().
 			RequestRepeatDelay(3*time.Second). // delay before new try
-			RequestRepeat(3). // count attempts
+			RequestRepeat(3).                  // count attempts
 			RequestBuilder(
 				cute.WithURL(u),
 				cute.WithMethod(http.MethodGet),

--- a/examples/single_test.go
+++ b/examples/single_test.go
@@ -21,6 +21,21 @@ import (
 	"github.com/ozontech/cute/asserts/json"
 )
 
+func TestUploadfile(t *testing.T) {
+	cute.NewTestBuilder().
+		Title("Super test").
+		Create().
+		RequestBuilder(
+			cute.WithURI("http://localhost:7000/v1/admin/banner"),
+			cute.WithMethod("POST"),
+			cute.WithFormKV("body", []byte("{  \"banner\": {    \"companies\": [],    \"finish_date\": \"2023-10-02\",    \"start_date\": \"2021-01-08\",    \"priority\": 0,    \"url\": \"\",    \"users\": []  }}")),
+			cute.WithFileFormKV("image", &cute.File{
+				Path: "/Users/makarovserge/Downloads/gogogo.png",
+			}),
+		).
+		ExecuteTest(context.Background(), t)
+}
+
 func Test_Single_1(t *testing.T) {
 	cute.NewTestBuilder().
 		Title("Single test with default T").

--- a/examples/suite/one_step.go
+++ b/examples/suite/one_step.go
@@ -119,9 +119,9 @@ func (i *ExampleSuite) Test_OneStep(t provider.T) {
 			json.Equal("$[0].email", "Eliseo@gardner.biz"),
 			json.Present("$[1].name"),
 			json.NotPresent("$[1].some_not_present"),
-			json.GreaterThan("$", 3),
+			json.LengthGreaterThan("$", 3),
 			json.Length("$", 5),
-			json.LessThan("$", 100),
+			json.LengthLessThan("$", 100),
 			json.NotEqual("$[3].name", "kekekekeke"),
 
 			// Custom assert body

--- a/examples/suite/one_step_errors.go
+++ b/examples/suite/one_step_errors.go
@@ -45,7 +45,7 @@ func (i *ExampleSuite) Test_OneStep_Errors(t provider.T) {
 		AssertBody(
 			json.Equal("$[0].email", "something"),
 			json.Present("$[1].not_present"),
-			json.GreaterThan("$", 99999),
+			json.LengthGreaterThan("$", 99999),
 			json.Length("$", 0),
 			// Custom assert body
 			examples.CustomAssertBody(),

--- a/interface.go
+++ b/interface.go
@@ -53,21 +53,11 @@ type AllureLabelsBuilder interface {
 	Labels(labels ...*allure.Label) AllureBuilder
 }
 
-// StepBuilder is a scope of methods for set step information
-// Deprecated.
-type StepBuilder interface {
-	// StepName is a function to wrap a Test in new steps with Name
-	StepName(name string) MiddlewareRequest
-}
-
 // CreateBuilder is functions for create Test or table tests
 type CreateBuilder interface {
 	// Create is a function for save main information about allure and start write tests
 	Create() MiddlewareRequest
 
-	// CreateWithStep is a function for create step and log some information inside
-	// Deprecated, please use CreateStep(string)
-	CreateWithStep() StepBuilder
 	// CreateStep is a function for create step inside suite for Test
 	CreateStep(string) MiddlewareRequest
 
@@ -238,6 +228,10 @@ type ExpectHTTPBuilder interface {
 	// OptionalAssertResponseT is not a mandatory assert.
 	// Mark in allure as Broken
 	OptionalAssertResponseT(asserts ...AssertResponseT) ExpectHTTPBuilder
+
+	// EnableHardValidation is enabled hard validation,
+	// If one of assert was failed, test will stopped.
+	EnableHardValidation() ExpectHTTPBuilder
 
 	After
 	ControlTest

--- a/internal/utils/body.go
+++ b/internal/utils/body.go
@@ -33,5 +33,6 @@ func DrainBody(body io.ReadCloser) (r1, r2 io.ReadCloser, err error) {
 	if err = body.Close(); err != nil {
 		return nil, body, err
 	}
+
 	return io.NopCloser(&buf), io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 }

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestValidateJSONSchemaEmptySchema(t *testing.T) {
 	var (
-		tBuilder = createDefaultTest(nil)
+		tBuilder = createDefaultTest(&HTTPTestMaker{middleware: new(Middleware)})
 	)
 
 	errs := tBuilder.validateJSONSchema(nil, []byte{})
@@ -18,7 +18,7 @@ func TestValidateJSONSchemaEmptySchema(t *testing.T) {
 
 func TestValidateJSONSchemaFromString(t *testing.T) {
 	var (
-		tBuilder = createDefaultTest(nil)
+		tBuilder = createDefaultTest(&HTTPTestMaker{middleware: new(Middleware)})
 		tempT    = createAllureT(t)
 	)
 
@@ -57,7 +57,7 @@ func TestValidateJSONSchemaFromString(t *testing.T) {
 
 func TestValidateJSONSchemaFromStringWithError(t *testing.T) {
 	var (
-		tBuilder = createDefaultTest(nil)
+		tBuilder = createDefaultTest(&HTTPTestMaker{middleware: new(Middleware)})
 		tempT    = createAllureT(t)
 	)
 
@@ -105,7 +105,7 @@ func TestValidateJSONSchemaFromStringWithError(t *testing.T) {
 
 func TestValidateJSONSchemaFromByteWithTwoError(t *testing.T) {
 	var (
-		tBuilder = createDefaultTest(nil)
+		tBuilder = createDefaultTest(&HTTPTestMaker{middleware: new(Middleware)})
 		tempT    = createAllureT(t)
 	)
 

--- a/request.go
+++ b/request.go
@@ -6,6 +6,15 @@ import (
 
 type RequestBuilder func(o *requestOptions)
 
+// File is struct for upload file in form field
+// If you set Path, file will read from file system
+// If you set Name and Body, file will set from this fields
+type File struct {
+	Path string
+	Name string
+	Body []byte
+}
+
 type requestOptions struct {
 	method      string
 	url         *url.URL
@@ -13,6 +22,16 @@ type requestOptions struct {
 	headers     map[string][]string
 	body        []byte
 	bodyMarshal interface{}
+	fileForms   map[string]*File
+	forms       map[string][]byte
+}
+
+func newRequestOptions() *requestOptions {
+	return &requestOptions{
+		headers:   make(map[string][]string),
+		fileForms: make(map[string]*File),
+		forms:     make(map[string][]byte),
+	}
 }
 
 // WithMethod is a function for set method (GET, POST ...) in request
@@ -43,6 +62,13 @@ func WithHeaders(headers map[string][]string) func(o *requestOptions) {
 	}
 }
 
+// WithHeadersKV is a function for set headers in request
+func WithHeadersKV(name string, value string) func(o *requestOptions) {
+	return func(o *requestOptions) {
+		o.headers[name] = []string{value}
+	}
+}
+
 // WithBody is a function for set body in request
 func WithBody(body []byte) func(o *requestOptions) {
 	return func(o *requestOptions) {
@@ -54,5 +80,37 @@ func WithBody(body []byte) func(o *requestOptions) {
 func WithMarshalBody(body interface{}) func(o *requestOptions) {
 	return func(o *requestOptions) {
 		o.bodyMarshal = body
+	}
+}
+
+// WithFileFormKV is a function for set file form in request
+func WithFileFormKV(name string, file *File) func(o *requestOptions) {
+	return func(o *requestOptions) {
+		o.fileForms[name] = file
+	}
+}
+
+// WithFileForm is a function for set file form in request
+func WithFileForm(fileForms map[string]*File) func(o *requestOptions) {
+	return func(o *requestOptions) {
+		for name, file := range fileForms {
+			o.fileForms[name] = file
+		}
+	}
+}
+
+// WithFormKV is a function for set body in form request
+func WithFormKV(name string, body []byte) func(o *requestOptions) {
+	return func(o *requestOptions) {
+		o.forms[name] = body
+	}
+}
+
+// WithForm is a function for set body in form request
+func WithForm(forms map[string][]byte) func(o *requestOptions) {
+	return func(o *requestOptions) {
+		for name, body := range forms {
+			o.forms[name] = body
+		}
 	}
 }

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -114,7 +114,7 @@ func addInformationRequest(t T, req *http.Request) error {
 	}
 
 	if c := curl.String(); len(c) <= 2048 {
-		t.Log("[Request]" + c)
+		t.Log("[Request] " + c)
 	} else {
 		t.Log("[Request] Do request")
 	}

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -115,6 +115,8 @@ func addInformationRequest(t T, req *http.Request) error {
 
 	if c := curl.String(); len(c) <= 2048 {
 		t.Log("[Request]" + c)
+	} else {
+		t.Log("[Request] Do request")
 	}
 
 	headers, err := utils.ToJSON(req.Header)

--- a/test.go
+++ b/test.go
@@ -114,6 +114,15 @@ func (it *Test) Execute(ctx context.Context, t testing.TB) ResultsHTTPBuilder {
 	return res
 }
 
+func (it *Test) clearFields() {
+	it.AllureStep = new(AllureStep)
+	it.Middleware = new(Middleware)
+	it.Expect = new(Expect)
+	it.Request = new(Request)
+	it.Request.Repeat = new(RequestRepeatPolitic)
+	it.Expect.JSONSchema = new(ExpectJSONSchema)
+}
+
 func (it *Test) initEmptyFields() {
 	it.httpClient = http.DefaultClient
 
@@ -162,6 +171,9 @@ func (it *Test) execute(ctx context.Context, allureProvider allureProvider) Resu
 	}
 
 	processTestErrors(allureProvider, errs)
+
+	// Remove from base struct all asserts
+	it.clearFields()
 
 	return newTestResult(name, resp, errs)
 }


### PR DESCRIPTION
## New

1) **Support** `multipart/form-data`
https://github.com/ozontech/cute/issues/31

```
func TestUploadfile(t *testing.T) {
	cute.NewTestBuilder().
		Title("Uploat file").
		Create().
		RequestBuilder(
			cute.WithURI("http://localhost:7000/v1/admin/banner"),
			cute.WithMethod("POST"),
			cute.WithFormKV("body", []byte("{\"age\": 42}")),
			cute.WithFileFormKV("image", &cute.File{
				Path: "/vasya/gogogo.png",
			}),
		).
		ExecuteTest(context.Background(), t)
}
```

2) **Implement hard validation**
https://github.com/ozontech/cute/issues/30

```
func TestUploadfile(t *testing.T) {
	cute.NewTestBuilder().
		Title("Uploat file").
		Create().
		RequestBuilder(
			cute.WithURI("http://localhost:7000/v1/admin/banner"),
			cute.WithMethod("POST"),
			cute.WithFormKV("body", []byte("{\"age\": 42}")),
			cute.WithFileFormKV("image", &cute.File{
				Path: "/vasya/gogogo.png",
			}),
		).
                EnableHardValidation(). <- enable hard validation
                ExpectStatus(http.StatusOK).
		ExecuteTest(context.Background(), t)
}
```

3) **Rename asserts**

```
 GreaterThan => LengthGreaterThan
 GreaterOrEqualThan  => LengthGreaterOrEqualThan
 LessThan => LengthLessThan
 LessOrEqualThan => LengthLessOrEqualThan
```

4) **Implement common after/before test** 
https://github.com/ozontech/cute/issues/32

```

func TestName(t *testing.T) {
	testMaker := cute.NewHTTPTestMaker(
		cute.WithMiddlewareAfterT(modules.LogTraceID),
	)
}

func LogTraceID(t cute.T, response *http.Response, errors []error) error {
	t.Logf("[o3_request_info] Trace_id - %v", response.Header.Get("x-trace-id"))

	return nil
}
```