### PR TITLE
[ISSUE-19] Add assert for json response

### DIFF
--- a/asserts/json/json.go
+++ b/asserts/json/json.go
@@ -63,6 +63,22 @@ func NotEqual(expression string, expect interface{}) cute.AssertBody {
 	}
 }
 
+// EqualJSON is a function to check json path expression value is equal to given json
+// About expression - https://goessner.net/articles/JsonPath/
+func EqualJSON(expression string, expect []byte) cute.AssertBody {
+	return func(body []byte) error {
+		return equalJSON(body, expression, expect)
+	}
+}
+
+// NotEqualJSON is a function to check json path expression value is not equal to given json
+// About expression - https://goessner.net/articles/JsonPath/
+func NotEqualJSON(expression string, expect []byte) cute.AssertBody {
+	return func(body []byte) error {
+		return notEqualJSON(body, expression, expect)
+	}
+}
+
 // Length is a function to asserts that value is the expected length
 // About expression - https://goessner.net/articles/JsonPath/
 func Length(expression string, expectLength int) cute.AssertBody {

--- a/asserts/json/json_test.go
+++ b/asserts/json/json_test.go
@@ -698,6 +698,199 @@ func TestNotEqual(t *testing.T) {
 	}
 }
 
+func TestEqualJSON(t *testing.T) {
+	tests := []jsonTest{
+		{
+			caseName:   "valid json",
+			data:       `{"first": 777, "second": [{"key_1": "some_key", "value": "some_value"}]}`,
+			expression: "$.second[0].value",
+			expect:     `"some_value"`,
+			IsNilErr:   true,
+		},
+		{
+			caseName: "not valid json",
+			data:     "{not_valid_json}",
+		},
+		{
+			caseName:   "3rd party key",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.l",
+		},
+		{
+			caseName:   "not array",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.b[bs]",
+		},
+		{
+			caseName:   "valid array",
+			data:       `{"arr": ["one","two"]}`,
+			expression: "$.arr",
+			expect:     `["one", "two"]`,
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "check equal map",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.b",
+			expect:     `{"bs": "sb"}`,
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "check equal string",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     `"as"`,
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "check equal not correct string",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     `"not_correct"`,
+		},
+		{
+			caseName:   "check deep equal",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$",
+			expect:     `{ "b": {"bs": "sb"}, "a":"as" }`,
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "check deep equal not correct",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$",
+			expect:     `{ "b": {"sb": "bs"}, "a":"as" }`,
+		},
+		{
+			caseName:   "check 186135434",
+			data:       `{"a":186135434, "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     "186135434",
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "check float",
+			data:       `{"a":1.0000001, "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     "1.0000001",
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "check float 2",
+			data:       `{"a":999.0000001, "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     "999.0000001",
+			IsNilErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		exp, _ := test.expect.(string)
+		err := EqualJSON(test.expression, []byte(exp))([]byte(test.data))
+
+		if test.IsNilErr {
+			require.NoError(t, err, "failed test %v", test.caseName)
+		} else {
+			require.Error(t, err, "failed test %v", test.caseName)
+		}
+	}
+}
+
+func TestNotEqualJSON(t *testing.T) {
+	tests := []jsonTest{
+		{
+			caseName:   "valid json",
+			data:       `{"first": 777, "second": [{"key_1": "some_key", "value": "some_value"}]}`,
+			expression: "$.second[0].value",
+			expect:     `"some_value"`,
+		},
+		{
+			caseName: "not valid json",
+			data:     "{not_valid_json}",
+			IsNilErr: true,
+		},
+		{
+			caseName:   "3rd party key",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.l",
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "not array",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.b[bs]",
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "valid array",
+			data:       `{"arr": ["one","two"]}`,
+			expression: "$.arr",
+			expect:     `["one", "two"]`,
+		},
+		{
+			caseName:   "check equal map",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.b",
+			expect:     `{"bs": "sb"}`,
+		},
+		{
+			caseName:   "check equal string",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     `"as"`,
+		},
+		{
+			caseName:   "check equal not correct string",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     `"not_correct"`,
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "check deep equal",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$",
+			expect:     `{ "b": {"bs": "sb"}, "a":"as" }`,
+		},
+		{
+			caseName:   "check deep equal not correct",
+			data:       `{"a":"as", "b":{"bs":"sb"}}`,
+			expression: "$",
+			expect:     `{ "b": {"sb": "bs"}, "a":"as" }`,
+			IsNilErr:   true,
+		},
+		{
+			caseName:   "check 186135434",
+			data:       `{"a":186135434, "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     "186135434",
+		},
+		{
+			caseName:   "check float",
+			data:       `{"a":1.0000001, "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     "1.0000001",
+		},
+		{
+			caseName:   "check float 2",
+			data:       `{"a":999.0000001, "b":{"bs":"sb"}}`,
+			expression: "$.a",
+			expect:     "999.0000001",
+		},
+	}
+
+	for _, test := range tests {
+		exp, _ := test.expect.(string)
+		err := NotEqualJSON(test.expression, []byte(exp))([]byte(test.data))
+
+		if test.IsNilErr {
+			require.NoError(t, err, "failed test %v", test.caseName)
+		} else {
+			require.Error(t, err, "failed test %v", test.caseName)
+		}
+	}
+}
+
 func TestGetValueFromJSON(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/asserts/json/util.go
+++ b/asserts/json/util.go
@@ -3,6 +3,7 @@ package json
 import (
 	"bytes"
 	"fmt"
+	"github.com/ohler55/ojg/oj"
 	"reflect"
 	"strings"
 
@@ -60,6 +61,58 @@ func notEqual(data []byte, expression string, expect interface{}) error {
 	for _, value := range values {
 		if objectsAreEqual(value, expect) {
 			return errors.NewAssertError("NotEqual", fmt.Sprintf("on path %v. expect %v, but actual %v", expression, expect, value), value, expect)
+		}
+	}
+
+	return nil
+}
+
+// EqualJSON is a function to check json path expression value is equal to given json
+// About expression - https://goessner.net/articles/JsonPath/
+func equalJSON(data []byte, expression string, expect []byte) error {
+	values, err := GetValueFromJSON(data, expression)
+	if err != nil {
+		return err
+	}
+
+	obj, err := oj.Parse(expect)
+	if err != nil {
+		return fmt.Errorf("could not parse json in EqualJSON error: '%s'", err)
+	}
+
+	for _, value := range values {
+		if !objectsAreEqual(value, obj) {
+			return errors.NewAssertError(
+				"EqualJSON",
+				fmt.Sprintf("on path %v. expect %v (from json %v), but actual %v", expression, obj, expect, value),
+				value,
+				obj)
+		}
+	}
+
+	return nil
+}
+
+// NotEqualJSON is a function to check json path expression value is not equal to given json
+// About expression - https://goessner.net/articles/JsonPath/
+func notEqualJSON(data []byte, expression string, expect []byte) error {
+	values, err := GetValueFromJSON(data, expression)
+	if err != nil {
+		return err
+	}
+
+	obj, err := oj.Parse(expect)
+	if err != nil {
+		return fmt.Errorf("could not parse json in NotEqualJSON error: '%s'", err)
+	}
+
+	for _, value := range values {
+		if objectsAreEqual(value, obj) {
+			return errors.NewAssertError(
+				"NotEqualJSON",
+				fmt.Sprintf("on path %v. expect %v (from json %v), but actual %v", expression, obj, expect, value),
+				value,
+				obj)
 		}
 	}
 


### PR DESCRIPTION
P.S. I'm not completely sure that I understood the issue correctly as long as Equal("$", _json structure made with nested map[string]interface{} and arrays_) but I believe `EqualJSON("$", "{"a":"as", "b":{"bs":"sb"}}")` is a better option than `Equal("$", map[string]interface{}{"a": "as", "b": map[string]interface{}{"bs": "sb"}})`