### PR TITLE
[ISSUE-16] Add methods to hide data

### DIFF
--- a/builder_asserts.go
+++ b/builder_asserts.go
@@ -367,3 +367,27 @@ func (qt *cute) ExpectJSONSchemaFile(filePath string) ExpectHTTPBuilder {
 
 	return qt
 }
+
+func (qt *cute) HideBody() ExpectHTTPBuilder {
+	qt.tests[qt.countTests].HideBody = true
+
+	return qt
+}
+
+func (qt *cute) HideHeaders() ExpectHTTPBuilder {
+	qt.tests[qt.countTests].HideHeaders = true
+
+	return qt
+}
+
+func (qt *cute) HideResponse() ExpectHTTPBuilder {
+	qt.tests[qt.countTests].HideResponse = true
+
+	return qt
+}
+
+func (qt *cute) HideResponseHeaders() ExpectHTTPBuilder {
+	qt.tests[qt.countTests].HideResponseHeaders = true
+
+	return qt
+}

--- a/interface.go
+++ b/interface.go
@@ -296,6 +296,15 @@ type ExpectHTTPBuilder interface {
 	// Mark in allure as Broken
 	BrokenAssertResponseT(asserts ...AssertResponseT) ExpectHTTPBuilder
 
+	// HideBody is function for hide request body.
+	HideBody() ExpectHTTPBuilder
+	// HideHeaders is function for hide request headers.
+	HideHeaders() ExpectHTTPBuilder
+	// HideResponse is function for hide response body.
+	HideResponse() ExpectHTTPBuilder
+	// HideResponseHeaders is function for hide response headers.
+	HideResponseHeaders() ExpectHTTPBuilder
+
 	After
 	ControlTest
 }

--- a/test.go
+++ b/test.go
@@ -40,6 +40,11 @@ type Test struct {
 	Middleware *Middleware
 	Request    *Request
 	Expect     *Expect
+
+	HideBody            bool
+	HideHeaders         bool
+	HideResponse        bool
+	HideResponseHeaders bool
 }
 
 // Request is struct with HTTP request.
@@ -200,7 +205,6 @@ func (it *Test) executeInsideAllure(ctx context.Context, allureProvider allurePr
 		// Execute test inside step
 		resp, errs = it.startTestWithStep(ctx, allureProvider)
 	} else {
-
 		// Execute Test
 		resp, errs = it.startTest(ctx, allureProvider)
 	}
@@ -470,7 +474,6 @@ func (it *Test) buildRequest(ctx context.Context) (*http.Request, error) {
 	body := o.body
 	if o.bodyMarshal != nil {
 		body, err = it.jsonMarshaler.Marshal(o.bodyMarshal)
-
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Add an option to hide data from Allure reports. Sometimes it's necessary to conceal sensitive information such as Body or Headers from being displayed in Allure reports. 

I added 4 methods:

- `HideBody`
- `HideHeaders`
- `HideResponse`
- `HideResponseHeaders`

#16