### PR TITLE
add SanitizeURL hook for safe request masking before logging

### DIFF
--- a/builder_request.go
+++ b/builder_request.go
@@ -111,6 +111,14 @@ func (qt *cute) RequestRetryBroken(broken bool) RequestHTTPBuilder {
 	return qt
 }
 
+// RequestWithSanitizeHook assigns the provided SanitizeHook to the test,
+// allowing URL sanitization before logging or reporting.
+func (qt *cute) RequestWithSanitizeHook(hook SanitizeHook) RequestHTTPBuilder {
+	qt.tests[qt.countTests].Sanitizer = hook
+
+	return qt
+}
+
 func (qt *cute) Request(r *http.Request) ExpectHTTPBuilder {
 	qt.tests[qt.countTests].Request.Base = r
 

--- a/interface.go
+++ b/interface.go
@@ -218,6 +218,12 @@ type RequestParams interface {
 	// Deprecated: use RequestRetryBroken instead
 	RequestRepeatBroken(broken bool) RequestHTTPBuilder
 	RequestRetryBroken(broken bool) RequestHTTPBuilder
+
+	// RequestWithSanitizeHook sets a SanitizeHook function for the request.
+	// This hook allows you to modify or mask parts of the request URL (e.g., hide sensitive data)
+	// before it is logged or added to the test report (Allure).
+	// Example usage: RequestWithSanitizeHook(func(req *http.Request) { ... }).
+	RequestWithSanitizeHook(hook SanitizeHook) RequestHTTPBuilder
 }
 
 // ExpectHTTPBuilder is a scope of methods for validate http response

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -148,6 +148,8 @@ func (it *Test) addInformationRequest(t T, req *http.Request) error {
 		err      error
 	)
 
+	it.lastRequestURL = req.URL.String()
+
 	curl, err := http2curl.GetCurlCommand(req)
 	if err != nil {
 		return err

--- a/test.go
+++ b/test.go
@@ -29,6 +29,8 @@ var (
 	errorRequestURLEmpty    = errors.New("url request must be not empty")
 )
 
+// SanitizeHook is a function used to modify the request URL
+// before it is logged or attached to test reports (e.g., for hiding secrets).
 type SanitizeHook func(req *http.Request)
 
 // Test is a main struct of test.
@@ -477,6 +479,9 @@ func (it *Test) beforeTest(t internalT, req *http.Request) []error {
 	})
 }
 
+// createRequest builds the final *http.Request to be executed by the test.
+// If the Test.SanitizeURL hook is defined, it will be called after validation
+// to allow safe modification of the request before logging or execution.
 func (it *Test) createRequest(ctx context.Context) (*http.Request, error) {
 	var (
 		req = it.Request.Base
@@ -495,6 +500,7 @@ func (it *Test) createRequest(ctx context.Context) (*http.Request, error) {
 		return nil, err
 	}
 
+	// Apply optional request sanitizer (e.g., for hiding sensitive query params)
 	if it.SanitizeURL != nil {
 		it.SanitizeURL(req)
 	}

--- a/test.go
+++ b/test.go
@@ -50,7 +50,7 @@ type Test struct {
 	Request    *Request
 	Expect     *Expect
 
-	SanitizeURL SanitizeHook
+	Sanitizer SanitizeHook
 }
 
 // Retry is a struct to control the retry of a whole single test (not only the request)
@@ -482,7 +482,7 @@ func (it *Test) beforeTest(t internalT, req *http.Request) []error {
 }
 
 // createRequest builds the final *http.Request to be executed by the test.
-// If the Test.SanitizeURL hook is defined, it will be called after validation
+// If the Test.Sanitizer hook is defined, it will be called after validation
 // to allow safe modification of the request before logging or execution.
 func (it *Test) createRequest(ctx context.Context) (*http.Request, error) {
 	var (
@@ -502,8 +502,8 @@ func (it *Test) createRequest(ctx context.Context) (*http.Request, error) {
 		return nil, err
 	}
 
-	if it.SanitizeURL != nil {
-		it.SanitizeURL(req)
+	if it.Sanitizer != nil {
+		it.Sanitizer(req)
 	}
 
 	return req, nil

--- a/test.go
+++ b/test.go
@@ -500,10 +500,16 @@ func (it *Test) createRequest(ctx context.Context) (*http.Request, error) {
 		return nil, err
 	}
 
-	// Apply optional request sanitizer (e.g., for hiding sensitive query params)
+	// Make a backup copy of URL
+	originalURL := *req.URL
+
+	// Apply sanitizer for logging
 	if it.SanitizeURL != nil {
 		it.SanitizeURL(req)
 	}
+
+	// Roll back to original before sending
+	defer func() { req.URL = &originalURL }()
 
 	return req, nil
 }

--- a/test.go
+++ b/test.go
@@ -29,6 +29,8 @@ var (
 	errorRequestURLEmpty    = errors.New("url request must be not empty")
 )
 
+type SanitizeHook func(req *http.Request)
+
 // Test is a main struct of test.
 // You may field Request and Expect for create simple test
 // Parallel can be used to control the parallelism of a Test
@@ -40,10 +42,11 @@ type Test struct {
 	Parallel bool
 	Retry    *Retry
 
-	AllureStep *AllureStep
-	Middleware *Middleware
-	Request    *Request
-	Expect     *Expect
+	AllureStep  *AllureStep
+	Middleware  *Middleware
+	Request     *Request
+	Expect      *Expect
+	SanitizeURL SanitizeHook
 }
 
 // Retry is a struct to control the retry of a whole single test (not only the request)
@@ -490,6 +493,10 @@ func (it *Test) createRequest(ctx context.Context) (*http.Request, error) {
 	// Validate Request
 	if err := it.validateRequest(req); err != nil {
 		return nil, err
+	}
+
+	if it.SanitizeURL != nil {
+		it.SanitizeURL(req)
 	}
 
 	return req, nil

--- a/test.go
+++ b/test.go
@@ -37,17 +37,19 @@ type SanitizeHook func(req *http.Request)
 // You may field Request and Expect for create simple test
 // Parallel can be used to control the parallelism of a Test
 type Test struct {
-	httpClient    *http.Client
-	jsonMarshaler JSONMarshaler
+	httpClient     *http.Client
+	jsonMarshaler  JSONMarshaler
+	lastRequestURL string
 
 	Name     string
 	Parallel bool
 	Retry    *Retry
 
-	AllureStep  *AllureStep
-	Middleware  *Middleware
-	Request     *Request
-	Expect      *Expect
+	AllureStep *AllureStep
+	Middleware *Middleware
+	Request    *Request
+	Expect     *Expect
+
 	SanitizeURL SanitizeHook
 }
 
@@ -500,16 +502,9 @@ func (it *Test) createRequest(ctx context.Context) (*http.Request, error) {
 		return nil, err
 	}
 
-	// Make a backup copy of URL
-	originalURL := *req.URL
-
-	// Apply sanitizer for logging
 	if it.SanitizeURL != nil {
 		it.SanitizeURL(req)
 	}
-
-	// Roll back to original before sending
-	defer func() { req.URL = &originalURL }()
 
 	return req, nil
 }

--- a/test_test.go
+++ b/test_test.go
@@ -188,7 +188,7 @@ func TestSanitizeURLHook(t *testing.T) {
 				WithURI("http://localhost/api?key=123"),
 			},
 		},
-		SanitizeURL: sanitizeKeyParam("****"),
+		Sanitizer: sanitizeKeyParam("****"),
 	}
 
 	req, err := test.createRequest(context.Background())
@@ -213,7 +213,7 @@ func TestSanitizeURL_LastRequestURL(t *testing.T) {
 				WithURI("http://localhost/api?key=123"),
 			},
 		},
-		SanitizeURL: sanitizeKeyParam("****"),
+		Sanitizer: sanitizeKeyParam("****"),
 	}
 
 	allureT := createAllureT(t)


### PR DESCRIPTION
### Summary

Adds a `SanitizeURL` hook to the `Test` struct, allowing users to modify the request (e.g., mask API keys) **before logging or reporting**.

---

### Motivation

While using `cute` for integration tests, we found that sensitive query params like `?key=...` were exposed in Allure reports.  
We tried several approaches **without library changes**, but none masked the URLs in cute's built-in logs.

---

### Approaches we tried

**Example 1: Logging masked URL via Middleware**

```go
test.Middleware = &cute.Middleware{
    BeforeT: []cute.BeforeExecuteT{
        func(t cute.T, req *http.Request) error {
            safe := regexp.MustCompile(`key=[^&]+`).ReplaceAllString(req.URL.String(), "key=****")
            if stepper, ok := any(t).(interface {
                WithNewStep(name string, action func(stepCtx provider.StepCtx))
            }); ok {
                stepper.WithNewStep("Log masked URL", func(stepCtx provider.StepCtx) {
                    stepCtx.WithNewAttachment("Masked URL", allure.Text, []byte(safe))
                })
            }
            return nil
        },
    },
}
```
**Worked:** Added an Allure attachment.  
**Problem:** Did not affect cute's internal request logging.

---

**Example 2: Temporarily replacing `req.URL.RawQuery`**

```go
BeforeExecuteT: func(t cute.T, req *http.Request) error {
    original := req.URL.RawQuery
    req.URL.RawQuery = regexp.MustCompile(`key=[^&]+`).ReplaceAllString(original, "key=****")
    // log something
    req.URL.RawQuery = original
    return nil
},
```
**Worked:** Controlled masked URL.  
**Problem:** Too late — cute had already logged the request.

---

### What’s added

- `SanitizeHook` type with doc.
- `Sanitizer` field on `Test`.
- Call to hook inside `createRequest()`.
- Unit test `TestSanitizeURLHook`.
- Small helper `sanitizeKeyParam()`.

---

### Example usage

```go
test := &cute.Test{
    SanitizeURL: func(req *http.Request) {
        q := req.URL.Query()
        q.Set("key", "****")
        req.URL.RawQuery = q.Encode()
    },
}
```

---

### Notes

- This feature is opt-in.
- It minimally affects the codebase.
- Open to feedback on placement or naming.

Thanks for reviewing!
